### PR TITLE
Update configurations to use IAM role for clustering

### DIFF
--- a/modules/ei/manifests/params.pp
+++ b/modules/ei/manifests/params.pp
@@ -98,6 +98,7 @@ class ei::params {
 
   $aws_access_key = 'ACCESS_KEY'
   $aws_secret_key = 'SECRET_KEY'
+  $aws_iam_role = 'IAM_ROLE'
   $aws_region = 'REGION_NAME'
   $local_member_host = 'LOCAL-MEMBER-HOST'
   $aws_security_group='WSO2SecurityGroup'

--- a/modules/ei/templates/carbon-home/conf/axis2/axis2.xml.erb
+++ b/modules/ei/templates/carbon-home/conf/axis2/axis2.xml.erb
@@ -515,9 +515,9 @@
                     Service (GMS) using a TCP ping mechanism.
         -->
         <parameter name="membershipScheme">aws</parameter>
-
-        <parameter name="accessKey"><%= @aws_access_key %></parameter>
-        <parameter name="secretKey"><%= @aws_secret_key %></parameter>
+        <parameter name="iamRole"><%= @aws_iam_role %></parameter>
+<!--        <parameter name="accessKey"><%#= @aws_access_key %></parameter>-->
+<!--        <parameter name="secretKey"><%#= @aws_secret_key %></parameter>-->
         <parameter name="securityGroup"><%= @aws_security_group %></parameter>
         <parameter name="region"><%= @aws_region %></parameter>
         <parameter name="tagKey"><%= @aws_tag_key %></parameter>


### PR DESCRIPTION
## Purpose
> Update clustering configurations to use IAM role for hazelcast clustering

## Goals
> Update clustering configurations to use IAM role for hazelcast clustering

## Approach
> Add new clustering parameter iamRole in axis2.xml configuration file. Remove accessKey and secretKey parameters.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes